### PR TITLE
Faces manifests

### DIFF
--- a/faces-02-retries/color-profile.yaml
+++ b/faces-02-retries/color-profile.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: linkerd.io/v1alpha2
+kind: ServiceProfile
+metadata:
+  name: color.faces.svc.cluster.local
+  namespace: faces
+spec:
+  routes:
+  - condition:
+      method: GET
+      pathRegex: /.*
+    name: GET /
+    isRetryable: true

--- a/faces-02-retries/face-profile.yaml
+++ b/faces-02-retries/face-profile.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: linkerd.io/v1alpha2
+kind: ServiceProfile
+metadata:
+  name: face.faces.svc.cluster.local
+  namespace: faces
+spec:
+  routes:
+  - condition:
+      method: GET
+      pathRegex: /.*
+    name: GET /
+    isRetryable: true

--- a/faces-02-retries/smiley-profile.yaml
+++ b/faces-02-retries/smiley-profile.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: linkerd.io/v1alpha2
+kind: ServiceProfile
+metadata:
+  name: smiley.faces.svc.cluster.local
+  namespace: faces
+spec:
+  routes:
+  - condition:
+      method: GET
+      pathRegex: /.*
+    name: GET /
+    isRetryable: true

--- a/faces-03-timeouts/color-profile.yaml
+++ b/faces-03-timeouts/color-profile.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: linkerd.io/v1alpha2
+kind: ServiceProfile
+metadata:
+  name: color.faces.svc.cluster.local
+  namespace: faces
+spec:
+  routes:
+  - condition:
+      method: GET
+      pathRegex: /.*
+    name: GET /
+    isRetryable: true
+    timeout: 300ms

--- a/faces-03-timeouts/face-profile.yaml
+++ b/faces-03-timeouts/face-profile.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: linkerd.io/v1alpha2
+kind: ServiceProfile
+metadata:
+  name: face.faces.svc.cluster.local
+  namespace: faces
+spec:
+  routes:
+  - condition:
+      method: GET
+      pathRegex: /.*
+    name: GET /
+    isRetryable: true
+    timeout: 250ms

--- a/faces-03-timeouts/smiley-profile.yaml
+++ b/faces-03-timeouts/smiley-profile.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: linkerd.io/v1alpha2
+kind: ServiceProfile
+metadata:
+  name: smiley.faces.svc.cluster.local
+  namespace: faces
+spec:
+  routes:
+  - condition:
+      method: GET
+      pathRegex: /.*
+    name: GET /
+    isRetryable: true
+    timeout: 300ms

--- a/faces/color-profile.yaml
+++ b/faces/color-profile.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: linkerd.io/v1alpha2
+kind: ServiceProfile
+metadata:
+  creationTimestamp: null
+  name: color.faces.svc.cluster.local
+  namespace: faces
+spec:
+  routes:
+  - condition:
+      method: GET
+      pathRegex: /
+    name: GET /

--- a/faces/face-profile.yaml
+++ b/faces/face-profile.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: linkerd.io/v1alpha2
+kind: ServiceProfile
+metadata:
+  creationTimestamp: null
+  name: face.faces.svc.cluster.local
+  namespace: faces
+spec:
+  routes:
+  - condition:
+      method: GET
+      pathRegex: /
+    name: GET /

--- a/faces/faces-gui.yaml
+++ b/faces/faces-gui.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: faces-gui
+  namespace: faces
+spec:
+  type: ClusterIP
+  selector:
+    service: faces-gui
+  ports:
+  - port: 80
+    targetPort: http
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: faces-gui
+  namespace: faces
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: faces-gui
+  template:
+    metadata:
+      labels:
+        service: faces-gui
+    spec:
+      containers:
+      - name: faces-gui
+        image: dwflynn/faces-gui:0.8.0
+        imagePullPolicy: Always
+        ports:
+        - name: http
+          containerPort: 8000
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            cpu: 100m
+            memory: 128Mi

--- a/faces/faces.yaml
+++ b/faces/faces.yaml
@@ -1,0 +1,150 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: face
+  namespace: faces
+spec:
+  type: ClusterIP
+  selector:
+    service: face
+  ports:
+  - port: 80
+    targetPort: http
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: face
+  namespace: faces
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: face
+  template:
+    metadata:
+      labels:
+        service: face
+    spec:
+      containers:
+      - name: face
+        image: dwflynn/faces-service:0.8.0
+        imagePullPolicy: Always
+        ports:
+        - name: http
+          containerPort: 8000
+        env:
+        - name: FACES_SERVICE
+          value: "face"
+        - name: ERROR_FRACTION
+          value: "20"
+        # - name: DELAY_BUCKETS
+        #   value: "0,5,10,15,20,50,200,500,1500"
+        resources:
+          requests:
+            cpu: 300m     # The face service doesn't need much memory, but it does need more
+            memory: 64Mi  # CPU than the other backend services since it has to call the
+          limits:         # face and smiley services, then composite the results.
+            cpu: 500m
+            memory: 128Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: smiley
+  namespace: faces
+spec:
+  type: ClusterIP
+  selector:
+    service: smiley
+  ports:
+  - port: 80
+    targetPort: http
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: smiley
+  namespace: faces
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: smiley
+  template:
+    metadata:
+      labels:
+        service: smiley
+    spec:
+      containers:
+      - name: smiley
+        image: dwflynn/faces-service:0.8.0
+        imagePullPolicy: Always
+        ports:
+        - name: http
+          containerPort: 8000
+        env:
+        - name: FACES_SERVICE
+          value: "smiley"
+        - name: ERROR_FRACTION
+          value: "20"
+        - name: DELAY_BUCKETS
+          value: "0,5,10,15,20,50,200,500,1500"
+        resources:
+          requests:
+            cpu: 100m
+            memory: 64Mi
+          limits:
+            cpu: 250m
+            memory: 128Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: color
+  namespace: faces
+spec:
+  type: ClusterIP
+  selector:
+    service: color
+  ports:
+  - port: 80
+    targetPort: http
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: color
+  namespace: faces
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: color
+  template:
+    metadata:
+      labels:
+        service: color
+    spec:
+      containers:
+      - name: color
+        image: dwflynn/faces-service:0.8.0
+        imagePullPolicy: Always
+        ports:
+        - name: http
+          containerPort: 8000
+        env:
+        - name: FACES_SERVICE
+          value: "color"
+        - name: ERROR_FRACTION
+          value: "20"
+        - name: DELAY_BUCKETS
+          value: "0,5,10,15,20,50,200,500,1500"
+        resources:
+          requests:
+            cpu: 100m
+            memory: 64Mi
+          limits:
+            cpu: 250m
+            memory: 128Mi

--- a/faces/smiley-profile.yaml
+++ b/faces/smiley-profile.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: linkerd.io/v1alpha2
+kind: ServiceProfile
+metadata:
+  creationTimestamp: null
+  name: smiley.faces.svc.cluster.local
+  namespace: faces
+spec:
+  routes:
+  - condition:
+      method: GET
+      pathRegex: /
+    name: GET /


### PR DESCRIPTION
The `faces` directory has the initial manifests that we want Argo to install at the start.
`faces-02-retries` and `faces-03-timeouts` have things we'll use during the demo, in a TBD way. 🙂 

